### PR TITLE
Made to compile with more recent Arduino versions

### DIFF
--- a/MAX6675.cpp
+++ b/MAX6675.cpp
@@ -5,7 +5,6 @@
   http://creativecommons.org/licenses/by-sa/3.0/
 */
 
-#include <WProgram.h>
 #include <MAX6675.h>
 
 MAX6675::MAX6675(int CS_pin, int SO_pin, int SCK_pin, int units)

--- a/MAX6675.h
+++ b/MAX6675.h
@@ -8,7 +8,11 @@
 #ifndef MAX6675_h
 #define MAX6675_h
 
+#if defined(ARDUINO) && ARDUINO >= 100
+#include "Arduino.h"
+#else
 #include "WProgram.h"
+#endif
 
 class MAX6675
 {


### PR DESCRIPTION
WProgram no longer exists in Arduino. Instead, it has been replaced with Arduino.h.

This patch set adds conditionally including either Arduino.h or WProgram.h depending on Arduino version. It also removes a superfluous include from the implementation; the required header is included transitively by MAX6675.h.
